### PR TITLE
Fix SRP problem, add calculateU method, remove hashConcat method, tes…

### DIFF
--- a/Cryptopals_resolutions/5-Set_5/cryptopals_set_5_problem_36/include/SecureRemotePassword.hpp
+++ b/Cryptopals_resolutions/5-Set_5/cryptopals_set_5_problem_36/include/SecureRemotePassword.hpp
@@ -194,16 +194,19 @@ public:
                                       const std::string &NHex, unsigned int g);
 
   /**
-   * @brief Calculates a hash digest of the concatenation of two values.
+   * @brief Calculates the SRP scrambling parameter u = H(PAD(A) | PAD(B))
+   * according to RFC 5054.
    *
    * @param hashName The hash algorithm to use (e.g., "SHA-256").
-   * @param left The left value in plaintext
-   * @param right The right value in plaintext
-   * @return The hash digest in hexadecimal format.
+   * @param AHex The client's public key A in hexadecimal format.
+   * @param BHex The server's public key B in hexadecimal format.
+   * @param NHex The group prime N in hexadecimal format.
+   * @return The computed u value as an uppercase hexadecimal string.
    */
-  static const std::string calculateHashConcat(const std::string &hashName,
-                                               const std::string &left,
-                                               const std::string &right);
+  static const std::string calculateU(const std::string &hashName,
+                                      const std::string &AHex,
+                                      const std::string &BHex,
+                                      const std::string &NHex);
   /**
    * @brief Calculates the SRP private key 'x' according to RFC 5054.
    *

--- a/Cryptopals_resolutions/5-Set_5/cryptopals_set_5_problem_36/include/SessionData.hpp
+++ b/Cryptopals_resolutions/5-Set_5/cryptopals_set_5_problem_36/include/SessionData.hpp
@@ -36,7 +36,7 @@ struct SessionData {
   std::unique_ptr<MyCryptoLibrary::SecureRemotePassword> _secureRemotePassword;
   unsigned int _groupId;
   std::string _salt; // hexadecimal format
-  std::string _hash; // (e.g., "SHA-256", "SHA-384", "SHA-512").
+  std::string _hash; // (e.g., "SHA-1", "SHA-256", "SHA-384", "SHA-512").
   std::string _password;
   std::string _vHex;                // Store the verifier v in hex format
   bool registrationComplete{false}; // Indicates if registration is finished

--- a/Cryptopals_resolutions/5-Set_5/cryptopals_set_5_problem_36/solving_strategy.md
+++ b/Cryptopals_resolutions/5-Set_5/cryptopals_set_5_problem_36/solving_strategy.md
@@ -163,7 +163,7 @@ Client                        Server
   |<-----------------------------|
   |                              |
   | Compute:                     |
-  | x = H(s | P)                 |
+  | x = H(s | H(U|":"| P))       |
   | v = g^x mod N                |
   |                              |
   | Send U, v                    |
@@ -378,7 +378,7 @@ Client                        Server
 TBD bellow:
   |                              |
   | Compute:                     |
-  | x = H(s | P)                 |
+  | x = H(s | H(U|":"| P))       |
   | v = g^x mod N                |
   |                              |
   | Send U, v                    |
@@ -391,7 +391,7 @@ TBD end:
 
 Specifications more information:
 
-- x = H(s | P) computed as raw bytes;
+- x = H(s | H(U|":"| P)) computed as raw bytes;
 - Password using system-generated (recommended for cryptography testing)
   Generate a random string with high entropy.
   Use a secure PRNG (e.g., OpenSSL RAND_bytes, C++ std::random_device + std::uniform_int_distribution).
@@ -399,7 +399,7 @@ Specifications more information:
 
 30. Add an auxiliary method to generate a password, minimum size should be 16 bytes (Done)
 31. Generate a password at the client side (Done)
-32. Generate x = H(s | P) (Done)
+32. Generate x = H(s | H(U|":"| P)) (Done)
 33. Generate v = g^x mod N (Done)
 34. Add the following leg at the client: (Done)
 
@@ -486,7 +486,7 @@ Proposed communication flow present at RFC 2945 pg.5:
 
   # Client generates a, computes:
   # A = g^a mod N
-  # u = H(A | B)
+  # u = H(PAD(A) | PAD(B))
   # x = H(s | P)
   # S = (B - k * g^x) ^ (a + u * x) mod N
   # K = H(S)
@@ -494,7 +494,7 @@ Proposed communication flow present at RFC 2945 pg.5:
   U, A, M                     -->
                               <--   # U serves to keep track of the state
                                     # Server computes:
-                                    # u = H(A | B)
+                                    # u = H(PAD(A) | PAD(B))
                                     # S = (A * v^u) ^ b mod N
                                     # K = H(S)
                                     # M' = H(H(N) XOR H(g) | H(U) | s | A | B | K)
@@ -528,7 +528,7 @@ Glossary:
 
 - A: A = g^a mod N (already sent to server)
 - a in [1, N-1]
-- u is the scrambling parameter: u = H(A | B)
+- u is the scrambling parameter: u = H(PAD(A) | PAD(B))
 - S is the shared secret, at the client it is calculated as:
   S = (B - k \* g^x) ^ (a + u \* x) mod N
 - K = H(S), S should be converted to byte array before hashing
@@ -546,7 +546,7 @@ Glossary:
 
 **Server side**
 
-- u is the scrambling parameter: u = H(A | B)
+- u is the scrambling parameter: u = H(PAD(A) | PAD(B))
 - S = (A \* v^u) ^ b mod N
 
 41. Add the first leg on server side of the Secure Remote Password protocol, Authentication phase. Study phase (in progress)
@@ -571,8 +571,8 @@ Glossary:
 
   # Client generates a, computes:
   # A = g^a mod N
-  # u = H(A | B)
-  # x = H(s | P)
+  # u = H(PAD(A) | PAD(B))
+  # x = H(s | H(U|":"| P))
   # S = (B - k * g^x) ^ (a + u * x) mod N
   # K = H(S)
 ```
@@ -604,8 +604,8 @@ Glossary:
     **should be at least 256 bits long**, at the client side (Done)
 60. Add the calculation of the parameter A (public key), should be abstracted to a utility,
     **constrains: 1 < A < N**, at the client side (Done)
-61. Add the calculation of the parameter u = H(A | B), at the client side (Done)
-62. Add tests to the parameter u = H(A | B) using the method calculateHashConcat (Done)
+61. Add the calculation of the parameter u = H(PAD(A) | PAD(B)), at the client side (Done)
+62. Add tests to the parameter u = H(PAD(A) | PAD(B)) using the method calculateU (Done)
 63. Add the calculation of the parameter x = H(s | P), use method already implemented at the
     registration step, at the client side (Done)
 64. Add tests at the client side to ensure that x is well performed, as the output
@@ -653,8 +653,8 @@ curl -X POST http://localhost:18080/srp/auth/init \
 
   # Client generates a, computes:
   # A = g^a mod N
-  # u = H(A | B)
-  # x = H(s | P)
+  # u = H(PAD(A) | PAD(B))
+  # x = H(s | H(U|":"| P))
   # S = (B - k * g^x) ^ (a + u * x) mod N
   # K = H(S)
 ```
@@ -668,7 +668,7 @@ curl -X POST http://localhost:18080/srp/auth/init \
   U, A, M                     -->
                               <--   # U serves to keep track of the state
                                     # Server computes:
-                                    # u = H(A | B)
+                                    # u = H(PAD(A) | PAD(B))
                                     # S = (A * v^u) ^ b mod N
                                     # K = H(S)
                                     # M' = H(H(N) XOR H(g) | H(U) | s | A | B | K)
@@ -689,7 +689,7 @@ curl -X POST http://localhost:18080/srp/auth/init \
 80. Finish the sending of the data at the client side with the parameters U, A, M, during
     the srp/auth/complete (Done)
 81. Add the reception and verification of the data in the server at the srp/auth/complete endpoint (Done)
-82. Server calculation of u = H(A | B) (Done)
+82. Server calculation of u = H(PAD(A) | PAD(B)) (Done)
 83. Implement method of Server calculation of S = (A \* v^u) ^ b mod N (Done)
 84. Add a script to validate S = (A \* v^u) ^ b mod N at the server side (Done)
 85. Add unit tests to test S against the results obtained at the script (Done)
@@ -779,7 +779,7 @@ Client                        Server
 
   # Client generates a, computes:
   # A = g^a mod N
-  # u = H(A | B)
+  # u = H(PAD(A) | PAD(B))
   # x = H(s | H(U|":"| P))
   # S = (B - k * g^x) ^ (a + u * x) mod N
   # K = H(S)
@@ -801,13 +801,8 @@ Client                        Server
   # If valid, authentication is complete
 ```
 
-102.  Compare the implementation against the RFC-5054 to see if there is some mismatch (in progress)
+104.  Server calculation of K = H(S) (in progress)
 
-103.  When there is some non-deterministic value, place the RFC-5054 test vectors to get a deterministic
-      final value to the protocol, both S client and S server should match.
-      Then start replacing those values for the actual results of the intermediate methods, the results
-      should still match until a predefined point, the problem should appear during this process (TBD)
-104.  Server calculation of K = H(S) (TBD)
 105.  Server calculation of M' = H(H(N) XOR H(g) | H(U) | s | A | B | K) (TBD)
 106.  Add the calculation of the M' at the server side and the compare with the M received (TBD)
 107.  Add a method to calculate M2 (TBD)

--- a/Cryptopals_resolutions/5-Set_5/cryptopals_set_5_problem_36/src/Server.cpp
+++ b/Cryptopals_resolutions/5-Set_5/cryptopals_set_5_problem_36/src/Server.cpp
@@ -523,25 +523,23 @@ void Server::handleAuthenticationComplete() {
           _secureRemotePasswordMap.at(extractedClientId)->_peerPublicKeyHex =
               extractedAHex;
           // u calculation
-          _secureRemotePasswordMap.at(extractedClientId)->_uHex =
-              MyCryptoLibrary::SecureRemotePassword::calculateHashConcat(
-                  _srpParametersMap
-                      .at(_secureRemotePasswordMap.at(extractedClientId)
-                              ->_groupId)
-                      ._hashName,
-                  MessageExtractionFacility::hexToPlaintext(
-                      _secureRemotePasswordMap.at(extractedClientId)
-                          ->_peerPublicKeyHex),
-                  MessageExtractionFacility::hexToPlaintext(
-                      _secureRemotePasswordMap.at(extractedClientId)
-                          ->_publicKeyHex));
+          _secureRemotePasswordMap.at(extractedClientId)
+              ->_uHex = MyCryptoLibrary::SecureRemotePassword::calculateU(
+              _srpParametersMap
+                  .at(_secureRemotePasswordMap.at(extractedClientId)->_groupId)
+                  ._hashName,
+              _secureRemotePasswordMap.at(extractedClientId)->_peerPublicKeyHex,
+              _secureRemotePasswordMap.at(extractedClientId)->_publicKeyHex,
+              _srpParametersMap
+                  .at(_secureRemotePasswordMap.at(extractedClientId)->_groupId)
+                  ._nHex);
           if (_debugFlag) {
             std::cout
                 << "\n--- Server log | Scrambling parameter u generated at the "
                    "authentication phase---"
                 << std::endl;
             std::cout << "\tClient ID: " << extractedClientId << std::endl;
-            std::cout << "\tu = H(A | B): "
+            std::cout << "\tu = H(PAD(A) | PAD(B)): "
                       << _secureRemotePasswordMap.at(extractedClientId)->_uHex
                       << std::endl;
             std::cout << "----------------------" << std::endl;

--- a/Cryptopals_resolutions/5-Set_5/cryptopals_set_5_problem_36/src/runClient1.cpp
+++ b/Cryptopals_resolutions/5-Set_5/cryptopals_set_5_problem_36/src/runClient1.cpp
@@ -15,7 +15,7 @@ int main(void) {
   /* work to verify */
   const bool debugFlag{true};
   const std::string clientId{"Bob"};
-  const unsigned int requestedGroup{7};
+  const unsigned int requestedGroup{5};
   std::shared_ptr<Client> client =
       std::make_shared<Client>(clientId, debugFlag);
   const bool registrationResult =

--- a/Cryptopals_resolutions/5-Set_5/cryptopals_set_5_problem_36/testScripts/calculateU.py
+++ b/Cryptopals_resolutions/5-Set_5/cryptopals_set_5_problem_36/testScripts/calculateU.py
@@ -1,15 +1,20 @@
 import hashlib
 
 
-def hex_to_bytes(hexstr):
-    return bytes.fromhex(hexstr)
+def hex_to_bytes(hexstr, pad_bytes=None):
+    b = bytes.fromhex(hexstr)
+    if pad_bytes is not None and len(b) < pad_bytes:
+        b = b.rjust(pad_bytes, b"\x00")
+    return b
 
 
-def calculate_u(hash_name, A_hex, B_hex):
-    # Convert hex to bytes
-    A_bytes = hex_to_bytes(A_hex)
-    B_bytes = hex_to_bytes(B_hex)
-    # Concatenate A || B
+def calculate_u(hash_name, A_hex, B_hex, N_hex):
+    # Pad A and B to the byte length of N
+    N = int(N_hex, 16)
+    pad_bytes = (N.bit_length() + 7) // 8
+    A_bytes = hex_to_bytes(A_hex, pad_bytes)
+    B_bytes = hex_to_bytes(B_hex, pad_bytes)
+    # Concatenate PAD(A) || PAD(B)
     input_bytes = A_bytes + B_bytes
     # Select hash function
     hash_name = hash_name.lower().replace("-", "")
@@ -28,10 +33,15 @@ def calculate_u(hash_name, A_hex, B_hex):
 
 
 if __name__ == "__main__":
+    N_hex = "EEAF0AB9ADB38DD69C33F80AFA8FC5E86072618775FF3C0B9EA2314C9C256576D674DF7496EA81D3383B4813D692C6E0E0D5D8E250B98BE48E495C1D6089DAD15DC7D7B46154D6B6CE8EF4AD69B15D4982559B297BCF1885C529F566660E57EC68EDBC3C05726CC02FD4CBF4976EAA9AFD5138FE8376435B9FC61D2FC0EB06E3"
     A_hex = "61D5E490F6F1B79547B0704C436F523DD0E560F0C64115BB72557EC44352E8903211C04692272D8B2D1A5358A2CF1B6E0BFCF99F921530EC8E39356179EAE45E42BA92AEACED825171E1E8B9AF6D9C03E1327F44BE087EF06530E69F66615261EEF54073CA11CF5858F0EDFDFE15EFEAB349EF5D76988A3672FAC47B0769447B"
     B_hex = "BD0C61512C692C0CB6D041FA01BB152D4916A1E77AF46AE105393011BAF38964DC46A0670DD125B95A981652236F99D9B681CBF87837EC996C6DA04453728610D0C6DDB58B318885D7D82C7F8DEB75CE7BD4FBAA37089E6F9C6059F388838E7A00030B331EB76840910440B1B27AAEAEEB4012B7D7665238A8E3FB004B117B58"
     hash_name = "SHA-1"
-    u = calculate_u(hash_name, A_hex, B_hex)
-    print(f"u = {u}")
-    u_hex_expected = "CE38B9593487DA98554ED47D70A7AE5F462EF019"  # RFC 5054"
-    print(f"\nu_expected = {u_hex_expected}\n")
+    u = calculate_u(hash_name, A_hex, B_hex, N_hex)
+    print(f"u_obtained = {u}\n")
+    u_hex_expected = "CE38B9593487DA98554ED47D70A7AE5F462EF019"  # RFC 5054
+    print(f"u_expected = {u_hex_expected}\n")
+    if u == u_hex_expected:
+        print("u = H(PAD(A)| PAD(B)) values match for RFC vector tests")
+    else:
+        print("u = H(PAD(A)| PAD(B)) values don't match for RFC vector tests")

--- a/Cryptopals_resolutions/5-Set_5/cryptopals_set_5_problem_36/tests/test_SessionData.cpp
+++ b/Cryptopals_resolutions/5-Set_5/cryptopals_set_5_problem_36/tests/test_SessionData.cpp
@@ -237,6 +237,7 @@ protected:
       "B2D4F3F7DFA46C34BF6F5FE04BB842965A75B4714003F5C20D8279E2183D6D54"
       "CCEE840C9A76BCB83F633B98E4E141BFF5EE1D8DCCC4F2932C693A1A5ED474DE"};
   // RFC-5054 Test vector reference values for test purposes
+  const unsigned int _groupIdRFC5054TestVector{1};
   const std::string _usernameRFC5054TestVectorValue{"alice"};
   const std::string _passwordRFC5054TestVectorValue{"password123"};
   const std::string _saltRFC5054TestVectorValue{
@@ -408,7 +409,7 @@ TEST_F(SessionDataTest, SessionData_GetKMultiplierMap_ShouldMatchReference) {
  * values, matches the expected reference value from RFC-5054.
  */
 TEST_F(SessionDataTest,
-       CalculatePublicKeyClientWithRFC5054TestVector_ShouldMatchReference) {
+       CalculatePublicKey_ClientWithRFC5054TestVector_ShouldMatchReference) {
   const unsigned int groupId{1};
   const std::string privateKeyHex{_aRFC5054TestVectorValue};
   const std::string NHex{_srpParametersMap.at(groupId)._nHex};
@@ -435,7 +436,7 @@ TEST_F(SessionDataTest,
  * values, matches the expected reference value from RFC-5054.
  */
 TEST_F(SessionDataTest,
-       CalculatePublicKeyServerWithRFC5054TestVector_ShouldMatchReference) {
+       CalculatePublicKey_ServerWithRFC5054TestVector_ShouldMatchReference) {
   const unsigned int groupId{1};
   const std::string privateKeyHex{_bRFC5054TestVectorValue};
   const std::string NHex{_srpParametersMap.at(groupId)._nHex};
@@ -461,92 +462,90 @@ TEST_F(SessionDataTest,
 }
 
 /**
- * @test Test the correctness of the calculation of the u = H(A | B)
+ * @test Test the correctness of the calculation of the u = H(PAD(A) | PAD(B))
  * parameter with SHA-1.
  * @brief Verifies that the scrambling parameter u, computed from known A and
  * B values using SHA-1, matches the expected reference value and has the
  * correct length, using as inputs the RFC-5054 test vector.
  */
 TEST_F(SessionDataTest,
-       calculateHashConcatWithSHA1RFC5054TestVector_ShouldMatchReference) {
+       calculateU_WithSHA1RFC5054TestVector_ShouldMatchReference) {
   std::string hashName{"SHA-1"};
-  std::string uHex{MyCryptoLibrary::SecureRemotePassword::calculateHashConcat(
-      hashName,
-      MessageExtractionFacility::hexToPlaintext(_A_RFC5054TestVectorValue),
-      MessageExtractionFacility::hexToPlaintext(_B_RFC5054TestVectorValue))};
+  std::string uHex{MyCryptoLibrary::SecureRemotePassword::calculateU(
+      hashName, _A_RFC5054TestVectorValue, _B_RFC5054TestVectorValue,
+      _srpParametersMap.at(_groupIdRFC5054TestVector)._nHex)};
   EXPECT_EQ(uHex.length(), SHA_DIGEST_LENGTH * 2);
   EXPECT_EQ(uHex, _uRFC5054TestVectorValue);
 }
 
 /**
- * @test Test the correctness of the calculation of the u = H(A | B)
- * parameter with SHA-256.
+ * @test Test the correctness of the calculation of the u = H(PAD(A) | PAD(B))
+ * parameter with SHA-256, group 4.
  * @brief Verifies that the scrambling parameter u, computed from known A and
  * B values using SHA-256, matches the expected reference value and has the
  * correct length.
  */
-TEST_F(SessionDataTest, calculateHashConcatWithSHA256_ShouldMatchReference) {
-  std::string hashName{"SHA-256"};
-  std::string uHex{MyCryptoLibrary::SecureRemotePassword::calculateHashConcat(
-      hashName, MessageExtractionFacility::hexToPlaintext(_A_Hex),
-      MessageExtractionFacility::hexToPlaintext(_B_Hex))};
-  std::string expectedUHex{
+TEST_F(SessionDataTest, calculateU_WithSHA256Group4_ShouldMatchReference) {
+  const unsigned int groupId{4};
+  const std::string uHex{MyCryptoLibrary::SecureRemotePassword::calculateU(
+      _srpParametersMap.at(groupId)._hashName, _A_Hex, _B_Hex,
+      _srpParametersMap.at(groupId)._nHex)};
+  const std::string uExpected{
       "49510A0BB9F42F1068F4446E620A4DF30453369329F2A001EF33A72510AA1810"};
   EXPECT_EQ(uHex.length(), SHA256_DIGEST_LENGTH * 2);
-  EXPECT_EQ(uHex, expectedUHex);
+  EXPECT_EQ(uHex, uExpected);
 }
 
 /**
- * @test Test the correctness of the calculation of the u = H(A | B)
- * parameter with SHA-384.
+ * @test Test the correctness of the calculation of the u = H(PAD(A) | PAD(B))
+ * parameter with SHA-384, group 5.
  * @brief Verifies that the scrambling parameter u, computed from known A and
  * B values using SHA-384, matches the expected reference value and has the
  * correct length.
  */
-TEST_F(SessionDataTest, calculateHashConcatWithSHA384_ShouldMatchReference) {
-  std::string hashName{"SHA-384"};
-  std::string uHex{MyCryptoLibrary::SecureRemotePassword::calculateHashConcat(
-      hashName, MessageExtractionFacility::hexToPlaintext(_A_Hex),
-      MessageExtractionFacility::hexToPlaintext(_B_Hex))};
-  std::string expectedUHex{
-      "0314B21EC992117D9C5F683036DD2F475EC67FE8E645534598B728CB32B4CB5A"
-      "0140F855718AFE6C1D03A44E2B5639EC"};
+TEST_F(SessionDataTest, calculateU_WithSHA384Group5_ShouldMatchReference) {
+  const unsigned int groupId{5};
+  const std::string uHex{MyCryptoLibrary::SecureRemotePassword::calculateU(
+      _srpParametersMap.at(groupId)._hashName, _A_Hex, _B_Hex,
+      _srpParametersMap.at(groupId)._nHex)};
+  const std::string uExpected{
+      "B745B6C458C39420EF4544CBD57E5FDB0536E954AC9485D30139B0E5C4EF07E496801EB6"
+      "AF1E15B167A1E5A7F0ED9759"};
   EXPECT_EQ(uHex.length(), SHA384_DIGEST_LENGTH * 2);
-  EXPECT_EQ(uHex, expectedUHex);
+  EXPECT_EQ(uHex, uExpected);
 }
 
 /**
- * @test Test the correctness of the calculation of the u = H(A | B)
- * parameter with SHA-512.
+ * @test Test the correctness of the calculation of the u = H(PAD(A) | PAD(B))
+ * parameter with SHA-512, group 7.
  * @brief Verifies that the scrambling parameter u, computed from known A and
  * B values using SHA-512, matches the expected reference value and has the
  * correct length.
  */
-TEST_F(SessionDataTest, calculateHashConcatWithSHA512_ShouldMatchReference) {
-  std::string hashName{"SHA-512"};
-  std::string uHex{MyCryptoLibrary::SecureRemotePassword::calculateHashConcat(
-      hashName, MessageExtractionFacility::hexToPlaintext(_A_Hex),
-      MessageExtractionFacility::hexToPlaintext(_B_Hex))};
-  std::string expectedUHex{
-      "AB6BDCAAC999E71946DA5047698DD4EAA2146D8097D03628E394880D6D21672D"
-      "C12EEEC2BD18C4050E6D725C3FAC7D86CA10A79F3A08E277A872B521C4742CDF"};
+TEST_F(SessionDataTest, calculateU_WithSHA512Group7_ShouldMatchReference) {
+  const unsigned int groupId{7};
+  const std::string uHex{MyCryptoLibrary::SecureRemotePassword::calculateU(
+      _srpParametersMap.at(groupId)._hashName, _A_Hex, _B_Hex,
+      _srpParametersMap.at(groupId)._nHex)};
+  const std::string uExpected{
+      "5E5B4A7F0DF5B66664D943CFA951872B81B4497B51744E5F413D5906FF37B980F937AE3A"
+      "109A13A1EAC7B65A02C8AA8C6AAFC5B3242AE63165A1841E17D06DE7"};
   EXPECT_EQ(uHex.length(), SHA512_DIGEST_LENGTH * 2);
-  EXPECT_EQ(uHex, expectedUHex);
+  EXPECT_EQ(uHex, uExpected);
 }
 
 /**
  * @test Test that during the u calculation, it throws an exception for
  * an unknown hash name.
- * @brief Verifies that the calculateHashConcat method throws
+ * @brief Verifies that the calculateU method throws
  * std::invalid_argument when an unsupported hash algorithm is provided.
  */
-TEST_F(SessionDataTest,
-       calculateHashConcat_WithUnknownHash_ShouldThrowRuntimeError) {
+TEST_F(SessionDataTest, calculateU_WithUnknownHash_ShouldThrowRuntimeError) {
   const std::string unknownHash{"unknownHash"};
   try {
-    MyCryptoLibrary::SecureRemotePassword::calculateHashConcat(
-        unknownHash, MessageExtractionFacility::hexToPlaintext(_A_Hex),
-        MessageExtractionFacility::hexToPlaintext(_B_Hex));
+    const unsigned int groupId{7};
+    const std::string uHex{MyCryptoLibrary::SecureRemotePassword::calculateU(
+        unknownHash, _A_Hex, _B_Hex, _srpParametersMap.at(groupId)._nHex)};
   } catch (const std::invalid_argument &e) {
     EXPECT_THAT(std::string(e.what()),
                 ::testing::EndsWith("hash algorithm not recognized."));
@@ -556,16 +555,17 @@ TEST_F(SessionDataTest,
 /**
  * @test Test that during the u calculation, it throws an exception with
  * empty input parameters.
- * @brief Verifies that the calculateHashConcat method throws
+ * @brief Verifies that the calculateU method throws
  * std::invalid_argument when empty input parameters are provided.
  */
 TEST_F(SessionDataTest,
-       calculateHashConcat_WithEmptyInputParameters_ShouldThrowRuntimeError) {
-  const std::string hash{"SHA-256"};
+       calculateU_WithEmptyInputParameters_ShouldThrowRuntimeError) {
+  const unsigned int groupId{7};
   const std::string leftEmpty{}, rightEmpty{};
   try {
-    MyCryptoLibrary::SecureRemotePassword::calculateHashConcat(hash, leftEmpty,
-                                                               rightEmpty);
+    const std::string uHex{MyCryptoLibrary::SecureRemotePassword::calculateU(
+        _srpParametersMap.at(groupId)._hashName, leftEmpty, rightEmpty,
+        _srpParametersMap.at(groupId)._nHex)};
   } catch (const std::invalid_argument &e) {
     EXPECT_THAT(std::string(e.what()),
                 ::testing::EndsWith(
@@ -583,7 +583,7 @@ TEST_F(SessionDataTest,
  * and compatible with other SRP implementations.
  */
 TEST_F(SessionDataTest,
-       CalculateXWithSHA1RFC5054TestVector_ShouldMatchReference) {
+       CalculateX_WithSHA1RFC5054TestVector_ShouldMatchReference) {
   const std::string x{MyCryptoLibrary::SecureRemotePassword::calculateX(
       _hashNameRFC5054TestVectorValue, _usernameRFC5054TestVectorValue,
       _passwordRFC5054TestVectorValue, _saltRFC5054TestVectorValue)};
@@ -598,7 +598,7 @@ TEST_F(SessionDataTest,
  * input values. This ensures the implementation of x generation is correct
  * and compatible with other SRP implementations.
  */
-TEST_F(SessionDataTest, CalculateXWithSHA256_ShouldMatchReference) {
+TEST_F(SessionDataTest, CalculateX_WithSHA256_ShouldMatchReference) {
   const std::string hash{"SHA-256"};
   const std::string salt{
       "3F455AE2504D25D0E5A24E363358CD58A3E41EB18AD066FEB81A7A1E82369DED"};
@@ -618,7 +618,7 @@ TEST_F(SessionDataTest, CalculateXWithSHA256_ShouldMatchReference) {
  * input values. This ensures the implementation of x generation is correct
  * and compatible with other SRP implementations.
  */
-TEST_F(SessionDataTest, CalculateXWithSHA384_ShouldMatchReference) {
+TEST_F(SessionDataTest, CalculateX_WithSHA384_ShouldMatchReference) {
   const std::string hash{"SHA-384"};
   const std::string salt{"BFB160DEA15A3E9C974E1797AA02F8B1F0FBE6D97AA18E40577"
                          "C07A9E2F40BB02C8F612B42BADBCBE37691B9A2382B30"};
@@ -639,7 +639,7 @@ TEST_F(SessionDataTest, CalculateXWithSHA384_ShouldMatchReference) {
  * input values. This ensures the implementation of x generation is correct
  * and compatible with other SRP implementations.
  */
-TEST_F(SessionDataTest, CalculateXWithSHA512_ShouldMatchReference) {
+TEST_F(SessionDataTest, CalculateX_WithSHA512_ShouldMatchReference) {
   const std::string hash{"SHA-512"};
   const std::string salt{
       "6B479DEBFE96BB93AC51E60F534536E4E493549EE1DA41A145E415612FFBA766A2CEAF"
@@ -659,7 +659,7 @@ TEST_F(SessionDataTest, CalculateXWithSHA512_ShouldMatchReference) {
  * @brief Verifies that the calculateX method throws
  * std::invalid_argument when an unsupported hash algorithm is provided.
  */
-TEST_F(SessionDataTest, CalculateXUnknownHash_ShouldThrowAnError) {
+TEST_F(SessionDataTest, CalculateX_UnknownHash_ShouldThrowAnError) {
   try {
     const std::string unknownHash{"unknownHash"};
     const std::string salt{
@@ -681,7 +681,7 @@ TEST_F(SessionDataTest, CalculateXUnknownHash_ShouldThrowAnError) {
  * reference value.
  */
 TEST_F(SessionDataTest,
-       CalculateSClientGroup1RFC5054TestVector_ShouldMatchReference) {
+       CalculateSClient_Group1RFC5054TestVector_ShouldMatchReference) {
   const unsigned int groupId{1};
   const unsigned int g{_srpParametersMap.at(groupId)._g};
   const std::string NHex{_srpParametersMap.at(groupId)._nHex};
@@ -698,7 +698,7 @@ TEST_F(SessionDataTest,
  * @brief Verifies that the client side S calculation matches the expected
  * reference value.
  */
-TEST_F(SessionDataTest, CalculateSClientGroup1_ShouldMatchReference) {
+TEST_F(SessionDataTest, CalculateSClient_Group1_ShouldMatchReference) {
   const unsigned int groupId{1};
   const std::string kHex{
       MessageExtractionFacility::BIGNUMToHex(_kMap.at(groupId).get())};
@@ -720,7 +720,7 @@ TEST_F(SessionDataTest, CalculateSClientGroup1_ShouldMatchReference) {
  * @brief Verifies that the client side S calculation matches the expected
  * reference value.
  */
-TEST_F(SessionDataTest, CalculateSClientGroup2_ShouldMatchReference) {
+TEST_F(SessionDataTest, CalculateSClient_Group2_ShouldMatchReference) {
   const unsigned int groupId{2};
   const std::string kHex{
       MessageExtractionFacility::BIGNUMToHex(_kMap.at(groupId).get())};
@@ -744,7 +744,7 @@ TEST_F(SessionDataTest, CalculateSClientGroup2_ShouldMatchReference) {
  * @brief Verifies that the client side S calculation matches the expected
  * reference value.
  */
-TEST_F(SessionDataTest, CalculateSClientGroup3_ShouldMatchReference) {
+TEST_F(SessionDataTest, CalculateSClient_Group3_ShouldMatchReference) {
   const unsigned int groupId{3};
   const std::string kHex{
       MessageExtractionFacility::BIGNUMToHex(_kMap.at(groupId).get())};
@@ -770,7 +770,7 @@ TEST_F(SessionDataTest, CalculateSClientGroup3_ShouldMatchReference) {
  * @brief Verifies that the client side S calculation matches the expected
  * reference value.
  */
-TEST_F(SessionDataTest, CalculateSClientGroup4_ShouldMatchReference) {
+TEST_F(SessionDataTest, CalculateSClient_Group4_ShouldMatchReference) {
   const unsigned int groupId{4};
   const std::string kHex{
       MessageExtractionFacility::BIGNUMToHex(_kMap.at(groupId).get())};
@@ -800,7 +800,7 @@ TEST_F(SessionDataTest, CalculateSClientGroup4_ShouldMatchReference) {
  * @brief Verifies that the client side S calculation matches the expected
  * reference value.
  */
-TEST_F(SessionDataTest, CalculateSClientGroup5_ShouldMatchReference) {
+TEST_F(SessionDataTest, CalculateSClient_Group5_ShouldMatchReference) {
   const unsigned int groupId{5};
   const std::string kHex{
       MessageExtractionFacility::BIGNUMToHex(_kMap.at(groupId).get())};
@@ -834,7 +834,7 @@ TEST_F(SessionDataTest, CalculateSClientGroup5_ShouldMatchReference) {
  * @brief Verifies that the client side S calculation matches the expected
  * reference value.
  */
-TEST_F(SessionDataTest, CalculateSClientGroup6_ShouldMatchReference) {
+TEST_F(SessionDataTest, CalculateSClient_Group6_ShouldMatchReference) {
   const unsigned int groupId{6};
   const std::string kHex{
       MessageExtractionFacility::BIGNUMToHex(_kMap.at(groupId).get())};
@@ -875,7 +875,7 @@ TEST_F(SessionDataTest, CalculateSClientGroup6_ShouldMatchReference) {
  * @brief Verifies that the client side S calculation matches the expected
  * reference value.
  */
-TEST_F(SessionDataTest, CalculateSClientGroup7_ShouldMatchReference) {
+TEST_F(SessionDataTest, CalculateSClient_Group7_ShouldMatchReference) {
   const unsigned int groupId{7};
   const std::string kHex{
       MessageExtractionFacility::BIGNUMToHex(_kMap.at(groupId).get())};
@@ -924,7 +924,7 @@ TEST_F(SessionDataTest, CalculateSClientGroup7_ShouldMatchReference) {
  * @brief Verifies that K calculation matches the expected
  * reference value.
  */
-TEST_F(SessionDataTest, CalculateKHash1_ShouldMatchReference) {
+TEST_F(SessionDataTest, CalculateK_HashSHA1_ShouldMatchReference) {
   const std::string hash{"SHA-1"};
   const std::string K{
       MyCryptoLibrary::SecureRemotePassword::calculateK(hash, _SHex)};
@@ -938,7 +938,7 @@ TEST_F(SessionDataTest, CalculateKHash1_ShouldMatchReference) {
  * @brief Verifies that K calculation matches the expected
  * reference value.
  */
-TEST_F(SessionDataTest, CalculateKHash256_ShouldMatchReference) {
+TEST_F(SessionDataTest, CalculateK_HashSHA256_ShouldMatchReference) {
   const std::string hash{"SHA-256"};
   const std::string K{
       MyCryptoLibrary::SecureRemotePassword::calculateK(hash, _SHex)};
@@ -953,7 +953,7 @@ TEST_F(SessionDataTest, CalculateKHash256_ShouldMatchReference) {
  * @brief Verifies that K calculation matches the expected
  * reference value.
  */
-TEST_F(SessionDataTest, CalculateKHash384_ShouldMatchReference) {
+TEST_F(SessionDataTest, CalculateK_HashSHA384_ShouldMatchReference) {
   const std::string hash{"SHA-384"};
   const std::string K{
       MyCryptoLibrary::SecureRemotePassword::calculateK(hash, _SHex)};
@@ -969,7 +969,7 @@ TEST_F(SessionDataTest, CalculateKHash384_ShouldMatchReference) {
  * @brief Verifies that K calculation matches the expected
  * reference value.
  */
-TEST_F(SessionDataTest, CalculateKHash512_ShouldMatchReference) {
+TEST_F(SessionDataTest, CalculateK_HashSHA512_ShouldMatchReference) {
   const std::string hash{"SHA-512"};
   const std::string K{
       MyCryptoLibrary::SecureRemotePassword::calculateK(hash, _SHex)};
@@ -985,7 +985,7 @@ TEST_F(SessionDataTest, CalculateKHash512_ShouldMatchReference) {
  * @brief Verifies that the calculateK method throws
  * std::invalid_argument when an unsupported hash algorithm is provided.
  */
-TEST_F(SessionDataTest, CalculateKUnknownHash_ShouldThrowAnError) {
+TEST_F(SessionDataTest, CalculateK_UnknownHash_ShouldThrowAnError) {
   try {
     const std::string unknownHash{"unknownHash"};
     const std::string K{
@@ -1002,7 +1002,7 @@ TEST_F(SessionDataTest, CalculateKUnknownHash_ShouldThrowAnError) {
  * @brief Verifies that the calculateK method throws
  * std::invalid_argument when an empty input parameter is provided.
  */
-TEST_F(SessionDataTest, CalculateKWithEmptyInputParameter_ShouldThrowAnError) {
+TEST_F(SessionDataTest, CalculateK_WithEmptyInputParameter_ShouldThrowAnError) {
   try {
     const std::string hash{"SHA-256"};
     const std::string emptyS{};
@@ -1019,7 +1019,7 @@ TEST_F(SessionDataTest, CalculateKWithEmptyInputParameter_ShouldThrowAnError) {
  * @brief Verifies that M calculation matches the expected
  * reference value.
  */
-TEST_F(SessionDataTest, CalculateMHashSHA1_ShouldMatchReference) {
+TEST_F(SessionDataTest, CalculateM_HashSHA1_ShouldMatchReference) {
   const std::string hash{"SHA-1"};
   const unsigned int groupId{7};
   const std::string NHex{_srpParametersMap.at(groupId)._nHex};
@@ -1037,7 +1037,7 @@ TEST_F(SessionDataTest, CalculateMHashSHA1_ShouldMatchReference) {
  * @brief Verifies that M calculation matches the expected
  * reference value.
  */
-TEST_F(SessionDataTest, CalculateMHashSHA256_ShouldMatchReference) {
+TEST_F(SessionDataTest, CalculateM_HashSHA256_ShouldMatchReference) {
   const std::string hash{"SHA-256"};
   const unsigned int groupId{7};
   const std::string NHex{_srpParametersMap.at(groupId)._nHex};
@@ -1056,7 +1056,7 @@ TEST_F(SessionDataTest, CalculateMHashSHA256_ShouldMatchReference) {
  * @brief Verifies that M calculation matches the expected
  * reference value.
  */
-TEST_F(SessionDataTest, CalculateMHashSHA384_ShouldMatchReference) {
+TEST_F(SessionDataTest, CalculateM_HashSHA384_ShouldMatchReference) {
   const std::string hash{"SHA-384"};
   const unsigned int groupId{7};
   const std::string NHex{_srpParametersMap.at(groupId)._nHex};
@@ -1076,7 +1076,7 @@ TEST_F(SessionDataTest, CalculateMHashSHA384_ShouldMatchReference) {
  * @brief Verifies that M calculation matches the expected
  * reference value.
  */
-TEST_F(SessionDataTest, CalculateMHashSHA512_ShouldMatchReference) {
+TEST_F(SessionDataTest, CalculateM_HashSHA512_ShouldMatchReference) {
   const std::string hash{"SHA-512"};
   const unsigned int groupId{7};
   const std::string NHex{_srpParametersMap.at(groupId)._nHex};
@@ -1096,7 +1096,7 @@ TEST_F(SessionDataTest, CalculateMHashSHA512_ShouldMatchReference) {
  * @brief Verifies that the calculateM method throws
  * std::invalid_argument when an unsupported hash algorithm is provided.
  */
-TEST_F(SessionDataTest, CalculateMUnknownHash_ShouldThrowAnError) {
+TEST_F(SessionDataTest, CalculateM_UnknownHash_ShouldThrowAnError) {
   try {
     const std::string hash{"UNKNOWN-HASH"};
     const unsigned int groupId{7};
@@ -1117,7 +1117,7 @@ TEST_F(SessionDataTest, CalculateMUnknownHash_ShouldThrowAnError) {
  * @brief Verifies that the calculateM method throws
  * std::invalid_argument when an empty input parameter is provided.
  */
-TEST_F(SessionDataTest, CalculateMWithEmptyInputParameter_ShouldThrowAnError) {
+TEST_F(SessionDataTest, CalculateM_WithEmptyInputParameter_ShouldThrowAnError) {
   try {
     const std::string hash{"SHA-256"};
     const unsigned int groupId{7};
@@ -1139,7 +1139,7 @@ TEST_F(SessionDataTest, CalculateMWithEmptyInputParameter_ShouldThrowAnError) {
  * reference value.
  */
 TEST_F(SessionDataTest,
-       CalculateSServerGroup1RFC5054TestVector_ShouldMatchReference) {
+       CalculateSServer_Group1RFC5054TestVector_ShouldMatchReference) {
   const unsigned int groupId{1};
   const std::string NHex{_srpParametersMap.at(groupId)._nHex};
   const std::string S{MyCryptoLibrary::SecureRemotePassword::calculateSServer(
@@ -1154,7 +1154,7 @@ TEST_F(SessionDataTest,
  * @brief Verifies that the server side S calculation matches the expected
  * reference value.
  */
-TEST_F(SessionDataTest, CalculateSServerGroup7_ShouldMatchReference) {
+TEST_F(SessionDataTest, CalculateSServer_Group7_ShouldMatchReference) {
   const unsigned int groupId{7};
   const std::string NHex{_srpParametersMap.at(groupId)._nHex};
   const std::string S{MyCryptoLibrary::SecureRemotePassword::calculateSServer(
@@ -1199,7 +1199,7 @@ TEST_F(SessionDataTest, CalculateSServerGroup7_ShouldMatchReference) {
  * std::invalid_argument when invalid input parameters are provided.
  */
 TEST_F(SessionDataTest,
-       CalculateSServerInvalidInputParameters_ShouldThrowAnError) {
+       CalculateSServer_InvalidInputParameters_ShouldThrowAnError) {
   try {
     const unsigned int groupId{7};
     const std::string NHexInvalid{""};
@@ -1217,10 +1217,11 @@ TEST_F(SessionDataTest,
  * @brief Verifies that the verifier v, computed from known x, N, and g values,
  * matches the expected reference value from RFC-5054.
  */
-TEST_F(SessionDataTest, CalculateVWithRFC5054TestVector_ShouldMatchReference) {
+TEST_F(SessionDataTest, CalculateV_WithRFC5054TestVector_ShouldMatchReference) {
+  const unsigned int groupId{_groupIdRFC5054TestVector};
   const std::string xHex{_xRFC5054TestVectorValue};
-  const std::string NHex{_srpParametersMap.at(1)._nHex};
-  const unsigned int g{_srpParametersMap.at(1)._g};
+  const std::string NHex{_srpParametersMap.at(groupId)._nHex};
+  const unsigned int g{_srpParametersMap.at(groupId)._g};
   const std::string vHex{
       MyCryptoLibrary::SecureRemotePassword::calculateV(xHex, NHex, g)};
   EXPECT_EQ(vHex, _vRFC5054TestVectorValue);
@@ -1240,7 +1241,7 @@ TEST_F(SessionDataTest, CalculateVWithRFC5054TestVector_ShouldMatchReference) {
  * matches the expected reference value from RFC-5054.
  */
 TEST_F(SessionDataTest,
-       CalculateVWithRFC5054TestVectorGroup2_ShouldMatchReference) {
+       CalculateV_WithRFC5054TestVectorGroup2_ShouldMatchReference) {
   const unsigned int groupId{2};
   const std::string xHex{_xRFC5054TestVectorValue};
   const std::string NHex{_srpParametersMap.at(groupId)._nHex};
@@ -1271,7 +1272,7 @@ TEST_F(SessionDataTest,
  * matches the expected reference value from RFC-5054.
  */
 TEST_F(SessionDataTest,
-       CalculateVWithRFC5054TestVectorGroup3_ShouldMatchReference) {
+       CalculateV_WithRFC5054TestVectorGroup3_ShouldMatchReference) {
   const unsigned int groupId{3};
   const std::string xHex{_xRFC5054TestVectorValue};
   const std::string NHex{_srpParametersMap.at(groupId)._nHex};
@@ -1304,7 +1305,7 @@ TEST_F(SessionDataTest,
  * matches the expected reference value from RFC-5054.
  */
 TEST_F(SessionDataTest,
-       CalculateVWithRFC5054TestVectorGroup4_ShouldMatchReference) {
+       CalculateV_WithRFC5054TestVectorGroup4_ShouldMatchReference) {
   const unsigned int groupId{4};
   const std::string xHex{_xRFC5054TestVectorValue};
   const std::string NHex{_srpParametersMap.at(groupId)._nHex};
@@ -1340,7 +1341,7 @@ TEST_F(SessionDataTest,
  * matches the expected reference value from RFC-5054.
  */
 TEST_F(SessionDataTest,
-       CalculateVWithRFC5054TestVectorGroup5_ShouldMatchReference) {
+       CalculateV_WithRFC5054TestVectorGroup5_ShouldMatchReference) {
   const unsigned int groupId{5};
   const std::string xHex{_xRFC5054TestVectorValue};
   const std::string NHex{_srpParametersMap.at(groupId)._nHex};
@@ -1380,7 +1381,7 @@ TEST_F(SessionDataTest,
  * matches the expected reference value from RFC-5054.
  */
 TEST_F(SessionDataTest,
-       CalculateVWithRFC5054TestVectorGroup6_ShouldMatchReference) {
+       CalculateV_WithRFC5054TestVectorGroup6_ShouldMatchReference) {
   const unsigned int groupId{6};
   const std::string xHex{_xRFC5054TestVectorValue};
   const std::string NHex{_srpParametersMap.at(groupId)._nHex};
@@ -1427,7 +1428,7 @@ TEST_F(SessionDataTest,
  * matches the expected reference value from RFC-5054.
  */
 TEST_F(SessionDataTest,
-       CalculateVWithRFC5054TestVectorGroup7_ShouldMatchReference) {
+       CalculateV_WithRFC5054TestVectorGroup7_ShouldMatchReference) {
   const unsigned int groupId{7};
   const std::string xHex{_xRFC5054TestVectorValue};
   const std::string NHex{_srpParametersMap.at(groupId)._nHex};
@@ -1479,7 +1480,7 @@ TEST_F(SessionDataTest,
  * @brief Verifies that calculateV throws std::runtime_error when given empty
  * xHex, NHex, or g.
  */
-TEST_F(SessionDataTest, CalculateVWithEmptyInput_ShouldThrowRuntimeError) {
+TEST_F(SessionDataTest, CalculateV_WithEmptyInput_ShouldThrowRuntimeError) {
   EXPECT_THROW(MyCryptoLibrary::SecureRemotePassword::calculateV("", "ABCD", 2),
                std::invalid_argument);
   EXPECT_THROW(MyCryptoLibrary::SecureRemotePassword::calculateV("1234", "", 2),
@@ -1493,7 +1494,7 @@ TEST_F(SessionDataTest, CalculateVWithEmptyInput_ShouldThrowRuntimeError) {
  * @test Test the correctness of the calculation of v for a small group.
  * @brief Verifies that calculateV works for small values.
  */
-TEST_F(SessionDataTest, CalculateVWithSmallValues_ShouldMatchReference) {
+TEST_F(SessionDataTest, CalculateV_WithSmallValues_ShouldMatchReference) {
   const std::string xHex = "05";
   const std::string NHex = "17"; // 23 in decimal
   const unsigned int g = 2;


### PR DESCRIPTION
This pull request updates the Secure Remote Password (SRP) protocol implementation to align with RFC 5054, specifically regarding the calculation of the scrambling parameter `u` and the private key `x`. The changes replace legacy methods and documentation to ensure cryptographic correctness and interoperability, and clarify the protocol steps throughout the codebase and documentation.

### SRP protocol alignment and cryptographic correctness

* Replaced the calculation of the scrambling parameter `u` from a simple hash of concatenated public keys (`H(A | B)`) to the RFC 5054-compliant form using left-padded keys: `u = H(PAD(A) | PAD(B))`. This is implemented in the new `calculateU` method in `SecureRemotePassword`, with input validation and uppercase output. All usages of the old `calculateHashConcat` for `u` have been updated to use `calculateU`. [[1]](diffhunk://#diff-5dcd301b36b52dbb5b64b0bae1a12e5199d8dc80a862ddb5f2d91178e1c3cacdL197-R209) [[2]](diffhunk://#diff-dc84c851aa465179f4b7f1e050d7f5c7c47eb6e068e2abc070df6e9042b24ad3L492-R539) [[3]](diffhunk://#diff-a8d604292f6082e4e8bc711207f6ae7e49c509bc10c63b2322bfad2ae5d0d412L515-R531) [[4]](diffhunk://#diff-5e8bf169d141fda03cc3c9b4d2a0a7ad1dfbba82594fe701e8a52708a9527a1aL526-R542)
* Updated the calculation of the SRP private key `x` to use the RFC 5054 format: `x = H(s | H(U|":"|P))` instead of the previous `x = H(s | P)`. All related comments, debug logs, and documentation have been updated to reflect this change. [[1]](diffhunk://#diff-767817753d39f27a54708d69b2b995614a81411985faedf462f3a9fdf51702a8L166-R166) [[2]](diffhunk://#diff-767817753d39f27a54708d69b2b995614a81411985faedf462f3a9fdf51702a8L381-R381) [[3]](diffhunk://#diff-767817753d39f27a54708d69b2b995614a81411985faedf462f3a9fdf51702a8L394-R402) [[4]](diffhunk://#diff-a8d604292f6082e4e8bc711207f6ae7e49c509bc10c63b2322bfad2ae5d0d412L355-R369)

### Documentation and specification updates

* Revised all protocol documentation in `solving_strategy.md` to reflect the updated calculations for `u` and `x`, including step-by-step comments, glossary entries, and protocol flow diagrams. This ensures the documentation matches the implementation and RFC 5054. [[1]](diffhunk://#diff-767817753d39f27a54708d69b2b995614a81411985faedf462f3a9fdf51702a8L489-R497) [[2]](diffhunk://#diff-767817753d39f27a54708d69b2b995614a81411985faedf462f3a9fdf51702a8L531-R531) [[3]](diffhunk://#diff-767817753d39f27a54708d69b2b995614a81411985faedf462f3a9fdf51702a8L549-R549) [[4]](diffhunk://#diff-767817753d39f27a54708d69b2b995614a81411985faedf462f3a9fdf51702a8L574-R575) [[5]](diffhunk://#diff-767817753d39f27a54708d69b2b995614a81411985faedf462f3a9fdf51702a8L607-R608) [[6]](diffhunk://#diff-767817753d39f27a54708d69b2b995614a81411985faedf462f3a9fdf51702a8L656-R657) [[7]](diffhunk://#diff-767817753d39f27a54708d69b2b995614a81411985faedf462f3a9fdf51702a8L671-R671) [[8]](diffhunk://#diff-767817753d39f27a54708d69b2b995614a81411985faedf462f3a9fdf51702a8L692-R692) [[9]](diffhunk://#diff-767817753d39f27a54708d69b2b995614a81411985faedf462f3a9fdf51702a8L782-R782)

### Codebase cleanup

* Removed legacy debug output from the SRP secret calculation methods (`calculateSClient`, `calculateSServer`) to reduce noise and keep logs focused on protocol-relevant information. [[1]](diffhunk://#diff-dc84c851aa465179f4b7f1e050d7f5c7c47eb6e068e2abc070df6e9042b24ad3L587-L596) [[2]](diffhunk://#diff-dc84c851aa465179f4b7f1e050d7f5c7c47eb6e068e2abc070df6e9042b24ad3L693-L700)

### Minor clarifications

* Updated comments and parameter descriptions throughout the codebase to clarify the supported hash algorithms and protocol steps, improving maintainability and readability. [[1]](diffhunk://#diff-98567310fcd0e9923de39f23e84f8afe703bb3cb369028e0d2f47bf786367ee3L39-R39) [[2]](diffhunk://#diff-a8d604292f6082e4e8bc711207f6ae7e49c509bc10c63b2322bfad2ae5d0d412L355-R369)

These changes ensure the SRP implementation is cryptographically sound, RFC-compliant, and well-documented for future development and review.…ts as well